### PR TITLE
Fix error with @media preceeded by a comment

### DIFF
--- a/grammars/css.cson
+++ b/grammars/css.cson
@@ -12,11 +12,11 @@
     'include': '#selector'
   }
   {
-    'begin': '\\s*((@)charset\\b)\\s*'
+    'begin': '(@)charset\\b'
     'captures':
-      '1':
+      '0':
         'name': 'keyword.control.at-rule.charset.css'
-      '2':
+      '1':
         'name': 'punctuation.definition.keyword.css'
     'end': '\\s*((?=;|$))'
     'name': 'meta.at-rule.charset.css'
@@ -30,11 +30,11 @@
     ]
   }
   {
-    'begin': '\\s*((@)import\\b)\\s*'
+    'begin': '(@)import\\b'
     'captures':
-      '1':
+      '0':
         'name': 'keyword.control.at-rule.import.css'
-      '2':
+      '1':
         'name': 'punctuation.definition.keyword.css'
     'end': '\\s*((?=;|\\}))'
     'name': 'meta.at-rule.import.css'
@@ -75,7 +75,7 @@
     ]
   }
   {
-    'begin': '^\\s*((@)font-face)\\s*(?=\\{)'
+    'begin': '((@)font-face)\\s*(?=\\{)'
     'beginCaptures':
       '1':
         'name': 'keyword.control.at-rule.font-face.css'
@@ -90,14 +90,14 @@
     ]
   }
   {
-    'begin': '(?=^\\s*@media(\\s+|$))'
+    'begin': '(?=@media(\\s+|$))'
     'end': '\\s*(\\})'
     'endCaptures':
       '1':
         'name': 'punctuation.section.property-list.end.css'
     'patterns': [
       {
-        'begin': '^\\s*((@)media)(\\s+|$)'
+        'begin': '((@)media)(\\s+|$)'
         'beginCaptures':
           '1':
             'name': 'keyword.control.at-rule.media.css'
@@ -126,11 +126,11 @@
     ]
   }
   {
-    'begin': '\\s*((@)page\\b)\\s*'
+    'begin': '(@)page\\b'
     'captures':
-      '1':
+      '0':
         'name': 'keyword.control.at-rule.page.css'
-      '2':
+      '1':
         'name': 'punctuation.definition.keyword.css'
     'end': '\\s*((?=[{:]|$))'
     'name': 'meta.at-rule.page.css'
@@ -141,7 +141,7 @@
     ]
   }
   {
-    'begin': '\\s*((@)namespace\\b)\\s*(?=url)'
+    'begin': '((@)namespace\\b)\\s*(?=url)'
     'captures':
       '1':
         'name': 'keyword.control.at-rule.namespace.css'
@@ -165,7 +165,7 @@
     ]
   }
   {
-    'begin': '\\s*((@)namespace) ([\\w-]*)\\s*'
+    'begin': '((@)namespace) ([\\w-]*)'
     'captures':
       '1':
         'name': 'keyword.control.at-rule.namespace.scss'

--- a/spec/css-spec.coffee
+++ b/spec/css-spec.coffee
@@ -119,3 +119,13 @@ describe 'CSS grammar', ->
       expect(tokens[6]).toEqual value: ' ', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css']
       expect(tokens[7]).toEqual value: '"', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'string.quoted.double.css', 'punctuation.definition.string.begin.css']
       expect(tokens[8]).toEqual value: '\\c0ffee', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'string.quoted.double.css', 'constant.character.escape.css']
+
+  describe 'comments', ->
+    it 'tokenizes comments before media selectors', ->
+      {tokens} = grammar.tokenizeLine '/* comment */ @media'
+
+      expect(tokens[0]).toEqual value: '/*', scopes: ['source.css', 'comment.block.css', 'punctuation.definition.comment.css']
+      expect(tokens[1]).toEqual value: ' comment ', scopes: ['source.css', 'comment.block.css']
+      expect(tokens[2]).toEqual value: '*/', scopes: ['source.css', 'comment.block.css', 'punctuation.definition.comment.css']
+      expect(tokens[4]).toEqual value: '@', scopes: ['source.css', 'meta.at-rule.media.css', 'keyword.control.at-rule.media.css', 'punctuation.definition.keyword.css']
+      expect(tokens[5]).toEqual value: 'media', scopes: ['source.css', 'meta.at-rule.media.css', 'keyword.control.at-rule.media.css']


### PR DESCRIPTION
This pull request fixes an error reported in #33:

``` css
/** Comment */ @media (max-height: 40em){

}
```

See the [fix in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fpchaigno%2Flanguage-css%2Ffa3c1a4b7c52c59bf1e7258095c1a6bc33d6273c%2Fgrammars%2Fcss.cson&grammar_text=&code_source=from-text&code_url=&code=%2F**+Comment+*%2F+%40media+%28max-height%3A+40em%29{%0D%0A%0D%0A}).
